### PR TITLE
Add repository scan helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # megacorp
 
 The starter repo for the [Git 2 course](https://www.boot.dev/learn/learn-git-2) on Boot.dev.
+
+This repository includes a small helper script under `scripts/scan.sh` that lists files in the project and reports the total count.

--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -1,1 +1,8 @@
-# TODO: write the script
+#!/bin/sh
+set -eu
+
+printf 'Scanning repository files...\n'
+find . -maxdepth 2 -type f ! -path './.git/*' | sort
+printf '\nTotal files: '
+find . -maxdepth 2 -type f ! -path './.git/*' | wc -l | tr -d ' '
+printf '\n'


### PR DESCRIPTION
## Summary
- Adds a small repository scan helper script in `scripts/scan.sh`.
- Documents the helper in the README.

## Verification
- Ran `./scripts/scan.sh` successfully.
- Output included the project file list and total file count.